### PR TITLE
Added support for .vue single file components

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,15 +51,31 @@ We should add stuff here.
 
 ### Building Vue Components
 
-- Create new Vue Components in `/skins/GiantBomb/resources/components` as `.js` files
-  - See `/skins/GiantBomb/resources/components/VueExampleComponent.js` as an example
-- New Vue Components need to be added to `skin.json` as a seperate Resource Module
-  - See `skin.giantbomb.vueexamplecomponent` for example
-- Components must then be loaded via the components object in `/skins/GiantBomb/resources/components/index.js`
-- In any `.php` template use the attribute `data-vue-component=` on any DOM element
-  - See `/skins/GiantBomb/includes/GiantBombTemplate.php` as an example
-- Vue Component will be added to DOM as a child of that element
-- Props are fully functional, see `VueExampleComponent.js` for example
+#### Javascript Resource Module
+- Vue components can be defined as a `.js` file using the Vue [Single File Component](https://vuejs.org/api/sfc-spec.html) syntax.
+- Create new Vue Component in `/skins/GiantBomb/resources/components` as a `.js` file.
+  - See `/skins/GiantBomb/resources/components/VueExampleComponent.js` as an example.
+- Add component to `skin.json` as a separate Resource Module.
+  - See `skin.giantbomb.vueexamplecomponent` for example.
+
+#### Vue Single File Component
+- Vue components can be defined as a `.vue` file using the Vue [Single File Component](https://vuejs.org/api/sfc-spec.html) syntax.
+  - Supports styling component via the `<style>` tag.
+- Create new Vue Component in `/skins/GiantBomb/resources/components` as a `.vue` file.
+  - See `/skins/GiantBomb/resources/components/VueSingleFileComponentExample.vue` as an example.
+- Add component to `skin.json` within the `skins.giantbomb` Resource Module as a `packageFile`.
+  - See `skin.giantbomb` for example.
+
+### Binding Vue Components
+- To allow Vue Component to be bound to the DOM within a `.php` template, components must then be loaded via the components object in `/skins/GiantBomb/resources/components/index.js`.
+- In any `.php` template use the attribute `data-vue-component=` on any DOM element.
+  - See `/skins/GiantBomb/includes/GiantBombTemplate.php` as an example.
+- Vue Component will be added to DOM as a child of that element.
+- Props are fully functional by prefixing with `data-my-prop=` pattern, where `my-prop` is the name of your prop in kebab case, see `VueExampleComponent.js` for example.
+
+#### Binding Vue Components within other Vue components.
+- As long as the component has been included as per [Building Vue Components](#building-vue-components), it can be added to another Vue component via the `require` syntax.
+  - See `/skins/GiantBomb/resources/components/VueSingleFileComponentExample.vue` as an example.
 
 ## SemanticMediaWiki
 - Add more notes

--- a/skins/GiantBomb/includes/GiantBombTemplate.php
+++ b/skins/GiantBomb/includes/GiantBombTemplate.php
@@ -9,10 +9,17 @@ class GiantBombTemplate extends BaseTemplate {
             </head>
             <body>
                 <h1>Giant Bomb Wiki</h1>
-                <div
+
+                 <div
                     data-vue-component="VueExampleComponent"
                     data-label="An example vue component with props">
+                 </div>
+
+                <div
+                    data-vue-component="VueSingleFileComponentExample"
+                    data-title="My First SFC">
                 </div>
+
                 <?php echo $this->get('trailelement'); ?>
             </body>
         </html>

--- a/skins/GiantBomb/resources/components/AnotherVueComponent.vue
+++ b/skins/GiantBomb/resources/components/AnotherVueComponent.vue
@@ -1,0 +1,25 @@
+<template>
+  <div>
+    This is another Vue Component {{ someNumber }}
+  </div>
+</template>
+
+<script>
+
+const {toRefs} = require('vue');
+
+module.exports = {
+  name: 'App',
+  props: {
+    someNumber: Number
+  },
+  setup(props) {
+    const { someNumber } = toRefs(props)
+
+    return {
+      someNumber
+    }
+  }
+}
+
+</script>

--- a/skins/GiantBomb/resources/components/VueSingleFileComponentExample.vue
+++ b/skins/GiantBomb/resources/components/VueSingleFileComponentExample.vue
@@ -1,0 +1,28 @@
+<template>
+  <div>
+    Example of a Vue Single File Component with the title {{ title }}.
+    <another-vue-component :some-number="Math.random()"></another-vue-component>
+  </div>
+</template>
+
+<script>
+
+const {toRefs} = require('vue');
+const AnotherVueComponent = require('./AnotherVueComponent.vue')
+
+module.exports = {
+  name: 'App',
+  components: {AnotherVueComponent},
+  props: {
+    title: String
+  },
+  setup(props) {
+    const {title} = toRefs(props)
+
+    return {
+      title
+    }
+  }
+}
+
+</script>

--- a/skins/GiantBomb/resources/components/index.js
+++ b/skins/GiantBomb/resources/components/index.js
@@ -1,11 +1,14 @@
 const Vue = require('vue');
 
-// Add new Vue Componenets to components object
+// Add new Vue Components to components object
 // key: Vue Component Name
-// value: Require ResourceModule
-// ex: VueButton: require('skins.giantbomb.vuebutton')
+// value: Require ResourceModule or .Vue component
+// ex (ResourceModule): VueButton: require('skins.giantbomb.vuebutton')
+// ex (.Vue Component): VueButton: require('./VueButton.vue')
+// note: Only required for components being mounted to a php template via the 'data-vue-component' attribute.
 const components = {
-  VueExampleComponent: require('skins.giantbomb.vueexamplecomponent')
+  VueExampleComponent: require('skins.giantbomb.vueexamplecomponent'),
+  VueSingleFileComponentExample: require('./VueSingleFileComponentExample.vue')
 };
 
 Object.entries(components).forEach(([name, component]) => {

--- a/skins/GiantBomb/skin.json
+++ b/skins/GiantBomb/skin.json
@@ -29,7 +29,11 @@
       "styles": ["resources/css/styles.css"]
     },
     "skins.giantbomb": {
-      "packageFiles": ["resources/components/index.js"],
+      "packageFiles": [
+        "resources/components/index.js",
+        "resources/components/VueSingleFileComponentExample.vue",
+        "resources/components/AnotherVueComponent.vue"
+      ],
       "dependencies": ["skins.giantbomb.vueexamplecomponent", "vue"]
     }
   },


### PR DESCRIPTION
Added support to bind Vue components to a .php template in the .vue [Single File Component](https://vuejs.org/api/sfc-spec.html) syntax.

Included an example implementation, along with an example of binding a child Vue component within the parent one.

Kept existing support for defining Vue components in Javascript format, but believe we should make a decision to do it one way or the other to avoid inconsistency.