### PR TITLE
fix: nested html inside body element

### DIFF
--- a/skins/GiantBomb/includes/GiantBombTemplate.php
+++ b/skins/GiantBomb/includes/GiantBombTemplate.php
@@ -2,20 +2,11 @@
 class GiantBombTemplate extends BaseTemplate {
     public function execute() {
         ?>
-        <!DOCTYPE html>
-        <html>
-            <head>
-                <?php echo $this->get('headelement'); ?>
-            </head>
-            <body>
-                <h1>Giant Bomb Wiki</h1>
-                <div
-                    data-vue-component="VueExampleComponent"
-                    data-label="An example vue component with props">
-                </div>
-                <?php echo $this->get('trailelement'); ?>
-            </body>
-        </html>
+        <h1>Giant Bomb Wiki</h1>
+        <div
+            data-vue-component="VueExampleComponent"
+            data-label="An example vue component with props">
+        </div>
         <?php
     }
 }


### PR DESCRIPTION
I noticed today that inside `<body>` we had another `<html>`. This removes that nesting.

Before:

```html
<!DOCTYPE html>
<html class="client-nojs" lang="en" dir="ltr">
   <head>
      <meta charset="UTF-8">
      <title>Giant Bomb Wiki</title>
      <script>document.documentElement.className="client-js";RLCONF={"wgBreakFrames":false,"wgSeparatorTransformTable":["",""],"wgDigitTransformTable":["",""],"wgDefaultDateFormat":"dmy","wgMonthNames":["","January","February","March","April","May","June","July","August","September","October","November","December"],"wgRequestId":"db74808b33d9b1faea1b4de6","wgCanonicalNamespace":"","wgCanonicalSpecialPageName":false,"wgNamespaceNumber":0,"wgPageName":"Main_Page","wgTitle":"Main Page","wgCurRevisionId":2,"wgRevisionId":2,"wgArticleId":1,"wgIsArticle":true,"wgIsRedirect":false,"wgAction":"view","wgUserName":null,"wgUserGroups":["*"],"wgCategories":[],"wgPageViewLanguage":"en","wgPageContentLanguage":"en","wgPageContentModel":"wikitext","wgRelevantPageName":"Main_Page","wgRelevantArticleId":1,"wgIsProbablyEditable":true,"wgRelevantPageIsProbablyEditable":true,"wgRestrictionEdit":[],"wgRestrictionMove":[],"wgIsMainPage":true};RLSTATE={"site.styles":"ready","user.styles":"ready","user":"ready",
         "user.options":"loading","skins.giantbomb.styles":"ready"};RLPAGEMODULES=["site","mediawiki.page.ready","skins.giantbomb"];
      </script>
      <script>(RLQ=window.RLQ||[]).push(function(){mw.loader.impl(function(){return["user.options@12s5i",function($,jQuery,require,module){mw.user.tokens.set({"patrolToken":"+\\","watchToken":"+\\","csrfToken":"+\\"});
         }];});});
      </script>
      <link rel="stylesheet" href="/load.php?lang=en&amp;modules=skins.giantbomb.styles&amp;only=styles&amp;skin=giantbomb">
      <script async="" src="/load.php?lang=en&amp;modules=startup&amp;only=scripts&amp;raw=1&amp;skin=giantbomb"></script>
      <meta name="generator" content="MediaWiki 1.43.0">
      <meta name="robots" content="max-image-preview:standard">
      <meta name="format-detection" content="telephone=no">
      <meta name="viewport" content="width=1120">
      <link rel="alternate" type="application/x-wiki" title="Edit" href="/index.php?title=Main_Page&amp;action=edit">
      <link rel="search" type="application/opensearchdescription+xml" href="/rest.php/v1/search" title="Giant Bomb Wiki (en)">
      <link rel="EditURI" type="application/rsd+xml" href="http://localhost:8080/api.php?action=rsd">
      <link rel="alternate" type="application/atom+xml" title="Giant Bomb Wiki Atom feed" href="/index.php?title=Special:RecentChanges&amp;feed=atom">
   </head>
   <body class="mediawiki ltr sitedir-ltr mw-hide-empty-elt ns-0 ns-subject mw-editable page-Main_Page rootpage-Main_Page skin-giantbomb action-view">
      <!DOCTYPE html>
      <html>
         <head>
         </head>
         <body>
            <h1>Giant Bomb Wiki</h1>
            <div
               data-vue-component="VueExampleComponent"
               data-label="An example vue component with props">
            </div>
         </body>
      </html>
      <script>(RLQ=window.RLQ||[]).push(function(){mw.config.set({"wgBackendResponseTime":209,"wgPageParseReport":{"limitreport":{"cputime":"0.019","walltime":"0.029","ppvisitednodes":{"value":3,"limit":1000000},"postexpandincludesize":{"value":0,"limit":2097152},"templateargumentsize":{"value":0,"limit":2097152},"expansiondepth":{"value":2,"limit":100},"expensivefunctioncount":{"value":0,"limit":100},"unstrip-depth":{"value":0,"limit":20},"unstrip-size":{"value":0,"limit":5000000},"timingprofile":["100.00%    0.000      1 -total"]},"cachereport":{"timestamp":"20250704031246","ttl":86400,"transientcontent":false}}});});</script>
   </body>
</html>
```

After:
```html
<!DOCTYPE html>
<html class="client-nojs" lang="en" dir="ltr">
   <head>
      <meta charset="UTF-8">
      <title>Giant Bomb Wiki</title>
      <script>document.documentElement.className="client-js";RLCONF={"wgBreakFrames":false,"wgSeparatorTransformTable":["",""],"wgDigitTransformTable":["",""],"wgDefaultDateFormat":"dmy","wgMonthNames":["","January","February","March","April","May","June","July","August","September","October","November","December"],"wgRequestId":"9a5a0b978ae48d7fa5d1c81a","wgCanonicalNamespace":"","wgCanonicalSpecialPageName":false,"wgNamespaceNumber":0,"wgPageName":"Main_Page","wgTitle":"Main Page","wgCurRevisionId":2,"wgRevisionId":2,"wgArticleId":1,"wgIsArticle":true,"wgIsRedirect":false,"wgAction":"view","wgUserName":null,"wgUserGroups":["*"],"wgCategories":[],"wgPageViewLanguage":"en","wgPageContentLanguage":"en","wgPageContentModel":"wikitext","wgRelevantPageName":"Main_Page","wgRelevantArticleId":1,"wgIsProbablyEditable":true,"wgRelevantPageIsProbablyEditable":true,"wgRestrictionEdit":[],"wgRestrictionMove":[],"wgIsMainPage":true};RLSTATE={"site.styles":"ready","user.styles":"ready","user":"ready",
         "user.options":"loading","skins.giantbomb.styles":"ready"};RLPAGEMODULES=["site","mediawiki.page.ready","skins.giantbomb"];
      </script>
      <script>(RLQ=window.RLQ||[]).push(function(){mw.loader.impl(function(){return["user.options@12s5i",function($,jQuery,require,module){mw.user.tokens.set({"patrolToken":"+\\","watchToken":"+\\","csrfToken":"+\\"});
         }];});});
      </script>
      <link rel="stylesheet" href="/load.php?lang=en&amp;modules=skins.giantbomb.styles&amp;only=styles&amp;skin=giantbomb">
      <script async="" src="/load.php?lang=en&amp;modules=startup&amp;only=scripts&amp;raw=1&amp;skin=giantbomb"></script>
      <meta name="generator" content="MediaWiki 1.43.0">
      <meta name="robots" content="max-image-preview:standard">
      <meta name="format-detection" content="telephone=no">
      <meta name="viewport" content="width=1120">
      <link rel="alternate" type="application/x-wiki" title="Edit" href="/index.php?title=Main_Page&amp;action=edit">
      <link rel="search" type="application/opensearchdescription+xml" href="/rest.php/v1/search" title="Giant Bomb Wiki (en)">
      <link rel="EditURI" type="application/rsd+xml" href="http://localhost:8080/api.php?action=rsd">
      <link rel="alternate" type="application/atom+xml" title="Giant Bomb Wiki Atom feed" href="/index.php?title=Special:RecentChanges&amp;feed=atom">
   </head>
   <body class="mediawiki ltr sitedir-ltr mw-hide-empty-elt ns-0 ns-subject mw-editable page-Main_Page rootpage-Main_Page skin-giantbomb action-view">
      <h1>Giant Bomb Wiki</h1>
      <div
         data-vue-component="VueExampleComponent"
         data-label="An example vue component with props">
      </div>
      <script>(RLQ=window.RLQ||[]).push(function(){mw.config.set({"wgBackendResponseTime":305,"wgPageParseReport":{"limitreport":{"cputime":"0.011","walltime":"0.011","ppvisitednodes":{"value":3,"limit":1000000},"postexpandincludesize":{"value":0,"limit":2097152},"templateargumentsize":{"value":0,"limit":2097152},"expansiondepth":{"value":2,"limit":100},"expensivefunctioncount":{"value":0,"limit":100},"unstrip-depth":{"value":0,"limit":20},"unstrip-size":{"value":0,"limit":5000000},"timingprofile":["100.00%    0.000      1 -total"]},"cachereport":{"timestamp":"20250704031333","ttl":86400,"transientcontent":false}}});});</script>
   </body>
</html>
```