### PR TITLE
fix: remove npm ci

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -11,5 +11,4 @@ jobs:
       - uses: actions/checkout@v4
         with:
           ref: ${{ github.event.pull_request.head.sha }}
-      - run: (cd ./skins/GiantBomb && npm ci)
       - run: npx prettier --check .


### PR DESCRIPTION
I had that in there for the game press skin and didn't check if the gb one also had a package.json