### PR TITLE
fix: Update Dockerfile permissions and entrypoint script

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,6 +11,8 @@ RUN set -x; \
 
 COPY --from=composer:latest /usr/bin/composer /usr/local/bin/composer
 
+RUN chown -R root:root /var/www/html && chmod -R 777 /var/www/html
+
 RUN cd /var/www/html \
  && COMPOSER=composer.local.json php /usr/local/bin/composer require --no-update mediawiki/semantic-media-wiki \
  && php /usr/local/bin/composer require --no-update mediawiki/semantic-extra-special-properties \
@@ -28,4 +30,5 @@ RUN cd /var/www/html \
  
 # START CONTAINER
 COPY entrypoint.sh /entrypoint.sh
-ENTRYPOINT ["/bin/sh",/entrypoint.sh"]
+RUN chmod +x /entrypoint.sh
+ENTRYPOINT ["/bin/sh", "/entrypoint.sh"]


### PR DESCRIPTION
# Summary

This pull request fixes issues with the Docker build process by updating file permissions and ensuring the entrypoint script is executable.

## Changes

- Set ownership and permissions for `/var/www/html` to ensure proper access during the build.
- Made `entrypoint.sh` executable before setting it as the entrypoint.
- Fixed a typo (missing quotation mark) in the Dockerfile.

## Motivation

These changes resolve permission errors that prevented Composer from installing extensions during the Docker build, and ensure the container starts up correctly.

## Testing

- Successfully built the Docker image locally.
- Confirmed that all required extensions are installed and loaded.
- Verified that the container starts and the wiki is accessible at `http://localhost:8080`.
