### PR TITLE
Load wiki schema on startup for api dump

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ logs/
 !.vscode/settings.json
 !.vscode/extensions.json
 .DS_Store
+wiki_schema.sql

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,10 +5,7 @@ services:
       - .env
     volumes:
       - db-data:/var/lib/mysql
-<<<<<<< Updated upstream
-=======
       - ./wiki_schema.sql:/docker-entrypoint-initdb.d/wiki_schema.sql:ro
->>>>>>> Stashed changes
     healthcheck:
       test: "mariadb -uroot -p$MARIADB_ROOT_PASSWORD $MARIADB_DATABASE -e 'SHOW DATABASES;'"
       interval: 5s

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,6 +5,10 @@ services:
       - .env
     volumes:
       - db-data:/var/lib/mysql
+<<<<<<< Updated upstream
+=======
+      - ./wiki_schema.sql:/docker-entrypoint-initdb.d/wiki_schema.sql:ro
+>>>>>>> Stashed changes
     healthcheck:
       test: "mariadb -uroot -p$MARIADB_ROOT_PASSWORD $MARIADB_DATABASE -e 'SHOW DATABASES;'"
       interval: 5s


### PR DESCRIPTION
### Purpose
When the gb db is released, we will need to convert the data from those tables to the mediawiki structure. This PR is to create a database with the same schema as the gb db. 

### Follow ups
- Pull data from the GB API into this database. 
- Dump database into sql script
- Add dump sql script to db init
- Write script to convert to mediawiki structure

### Testing
wiki_schema.sql can be found in the discord, place it in the root directory and do a `docker-compose down -v` (only do this if you don't mind losing data in the db) followed by `docker-compose up -d`.

to verify the tables have been created:

grab the container id of the mariadb container from `docker ps`
run `docker exec -it <container id> bash`
run `mariadb -u root -p`
enter in the password found in the .env file for root
run `show databases;` and the gb_api_dump database should be there
run `use gb_api_dump;` followed by `show tables;` to see the list of imported tables 