### PR TITLE
add DisplayTitle and PageForms as extensions

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -41,8 +41,8 @@ RUN cd /var/www/html \
  && docker-php-ext-install zip \
  && cd /var/www/html/extensions/ \
  && git clone https://github.com/TopRealm/mediawiki-extensions-AddImgTag AddImgTag \
+ && git clone https://gerrit.wikimedia.org/r/mediawiki/extensions/PageForms.git \
  && git clone -b 'REL1_43' --single-branch --depth 1 https://gerrit.wikimedia.org/r/mediawiki/extensions/DisplayTitle \
- && git clone -b 'REL1_43' --single-branch --depth 1 https://gerrit.wikimedia.org/r/mediawiki/extensions/PageForms.git \
  && git clone -b 'REL1_43' --single-branch --depth 1 https://gerrit.wikimedia.org/r/mediawiki/extensions/TemplateStyles \
  && git clone -b 'REL1_43' --single-branch --depth 1 https://gerrit.wikimedia.org/r/mediawiki/extensions/Popups \
  && wget https://github.com/octfx/mediawiki-extensions-TemplateStylesExtender/archive/refs/tags/v2.0.0.zip \

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,7 +14,6 @@ RUN set -x; \
 
 COPY --from=composer:latest /usr/bin/composer /usr/local/bin/composer
 
-
 # LOAD API SCRIPTS - UNNEEDED AFTER DATA TRANSFERRED
 COPY ./gb_api_scripts /var/www/html/maintenance/gb_api_scripts/
 RUN if [ "$INSTALL_API" = "false" ]; then \
@@ -41,7 +40,9 @@ RUN cd /var/www/html \
  && docker-php-ext-configure zip \
  && docker-php-ext-install zip \
  && cd /var/www/html/extensions/ \
- && git clone https://github.com/TopRealm/mediawiki-extensions-AddImgTag AddImgTag \ 
+ && git clone https://github.com/TopRealm/mediawiki-extensions-AddImgTag AddImgTag \
+ && git clone -b 'REL1_43' --single-branch --depth 1 https://gerrit.wikimedia.org/r/mediawiki/extensions/DisplayTitle \
+ && git clone -b 'REL1_43' --single-branch --depth 1 https://gerrit.wikimedia.org/r/mediawiki/extensions/PageForms.git \
  && git clone -b 'REL1_43' --single-branch --depth 1 https://gerrit.wikimedia.org/r/mediawiki/extensions/TemplateStyles \
  && git clone -b 'REL1_43' --single-branch --depth 1 https://gerrit.wikimedia.org/r/mediawiki/extensions/Popups \
  && wget https://github.com/octfx/mediawiki-extensions-TemplateStylesExtender/archive/refs/tags/v2.0.0.zip \

--- a/config/LocalSettings.php
+++ b/config/LocalSettings.php
@@ -158,10 +158,7 @@ wfLoadSkin( 'Vector' );
 # wfLoadExtension( 'ExtensionName' );
 # to LocalSettings.php. Check specific extension documentation for more details.
 # The following extensions were automatically enabled:
-wfLoadExtension( 'AddImgTag' );
 wfLoadExtension( 'CodeEditor' );
-wfLoadExtension( 'DisplayTitle' );
-wfLoadExtension( 'PageForms' );
 wfLoadExtension( 'PageImages' );
 wfLoadExtension( 'ParserFunctions' );
 wfLoadExtension( 'Popups' );
@@ -180,11 +177,24 @@ wfLoadExtension( 'WikiEditor' );
 # End of automatically generated settings.
 # Add more configuration options below.
 
+wfLoadExtension( 'AddImgTag' );
+wfLoadExtension( 'DisplayTitle' );
+wfLoadExtension( 'PageForms' );
+
 $wgPFEnableStringFunctions = true;
 $wgPopupsHideOptInOnPreferencesPage = true;
 $wgPopupsReferencePreviewsBetaFeature = false;
-#$wgShowExceptionDetails = true;
+
+# Turn on subpages
+$wgNamespacesWithSubpages[NS_MAIN] = true;
+$wgNamespacesWithSubpages[NS_TEMPLATE] = true;
 
 # Allows the use of DISPLAYTITLE magic keyword
 $wgAllowDisplayTitle = true;
 $wgRestrictDisplayTitle = false;
+
+# Remove before prod push
+$wgShowExceptionDetails = true;
+$wgDevelopmentWarnings = true;
+error_reporting( -1 );
+ini_set( 'display_errors', 1 );

--- a/config/LocalSettings.php
+++ b/config/LocalSettings.php
@@ -160,6 +160,8 @@ wfLoadSkin( 'Vector' );
 # The following extensions were automatically enabled:
 wfLoadExtension( 'AddImgTag' );
 wfLoadExtension( 'CodeEditor' );
+wfLoadExtension( 'DisplayTitle' );
+wfLoadExtension( 'PageForms' );
 wfLoadExtension( 'PageImages' );
 wfLoadExtension( 'ParserFunctions' );
 wfLoadExtension( 'Popups' );
@@ -182,3 +184,7 @@ $wgPFEnableStringFunctions = true;
 $wgPopupsHideOptInOnPreferencesPage = true;
 $wgPopupsReferencePreviewsBetaFeature = false;
 #$wgShowExceptionDetails = true;
+
+# Allows the use of DISPLAYTITLE magic keyword
+$wgAllowDisplayTitle = true;
+$wgRestrictDisplayTitle = false;


### PR DESCRIPTION
## Purpose
PageForms will generate a form based on the template fields.
https://www.mediawiki.org/wiki/Extension:Page_Forms

DisplayTitle will allow for a replacement title instead of the page name as the title. e.g. page name is **LEGO_Ninjago_Shadow_of_Ronin** while display title would be **LEGO Ninjago: Shadow of Ronin**.  The extension will also default links to the display title.
https://www.mediawiki.org/wiki/Extension:Display_Title

## Testing
- rebuild the wiki image: `docker compose build wiki`
- start the containers: `docker compose up -d`
- go to http://localhost:8080/index.php/Special:Version and check the extensions appear in the Installed Extensions section

### Example Use

create http://localhost:8080/index.php/Locations with
```
location landing page

{{#ask: [[Category:Locations]] |?Name |format=table}}
```

create http://localhost:8080/index.php/Template:CreateWithFormLink with
```
<includeonly>
{{#formlink:
  form={{{1}}}
| link text=Create with form
| target={{PAGENAME}}
}}
</includeonly>
```

edit http://localhost:8080/index.php/MediaWiki:Noarticletext with
```
There is currently no text in this page.
You can [[Special:Search/{{PAGENAME}}|search for this page title]] in other pages,
<span class="plainlinks">[{{fullurl:{{#Special:Log}}|page={{FULLPAGENAMEE}}}} search the related logs],
or [{{fullurl:{{FULLPAGENAME}}|action=edit}} create this page]</span>.
{{#switch: {{#explode:{{PAGENAME}}|/|0}}
| Games = {{CreateWithFormLink|Game}}
| Locations = {{CreateWithFormLink|Location}}
}}
```

create with form http://localhost:8080/index.php/Property:Name and choose Text from the dropdown

create http://localhost:8080/index.php/Template:Location with
```
<includeonly>
{{DISPLAYTITLE:{{SUBPAGENAME}}}}
{{#set:
|Name={{{Name|}}}
}}
[[Category:Locations|{{SUBPAGENAME}}]]
</includeonly>
```

create with form http://localhost:8080/index.php/Form:Location and select the Location template from the dropdown
edit the page and upate the forminput line to be
```
{{#forminput:form=Location|super_page=Locations}}
```

With the setup done. Go to a random location like http://localhost:8080/index.php/Locations/Australia. There should be a link called "Create with form". This will take you to the page form for Location. After saving, the Australia page will appear and the title of the page will be Australia instead of Location/Australia.
