### PR TITLE
Update description converter to use the File syntax

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -40,7 +40,6 @@ RUN cd /var/www/html \
  && docker-php-ext-configure zip \
  && docker-php-ext-install zip \
  && cd /var/www/html/extensions/ \
- && git clone https://github.com/TopRealm/mediawiki-extensions-AddImgTag AddImgTag \
  && git clone https://gerrit.wikimedia.org/r/mediawiki/extensions/PageForms.git \
  && git clone -b 'REL1_43' --single-branch --depth 1 https://gerrit.wikimedia.org/r/mediawiki/extensions/DisplayTitle \
  && git clone -b 'REL1_43' --single-branch --depth 1 https://gerrit.wikimedia.org/r/mediawiki/extensions/TemplateStyles \

--- a/config/LocalSettings.php
+++ b/config/LocalSettings.php
@@ -98,10 +98,6 @@ if ($wikiEnv == 'prod') {
     $wgUploadPath = $wgScriptPath.'/images';
 }
 
-# Allow external images
-$wgAddImgTagWhitelist = true;
-$wgAddImgTagWhitelistDomainsList = ['www.giantbomb.com'];
-
 # InstantCommons allows wiki to use images from https://commons.wikimedia.org
 $wgUseInstantCommons = false;
 
@@ -177,7 +173,6 @@ wfLoadExtension( 'WikiEditor' );
 # End of automatically generated settings.
 # Add more configuration options below.
 
-wfLoadExtension( 'AddImgTag' );
 wfLoadExtension( 'DisplayTitle' );
 wfLoadExtension( 'PageForms' );
 

--- a/gb_api_scripts/converter.php
+++ b/gb_api_scripts/converter.php
@@ -321,19 +321,24 @@ class HtmlToMediaWikiConverter
             return false;
         }
 
-        $style = "";
         if ($align == 'right') {
-            $style = "style='float:right;margin-left:40px;max-width:280px;' ";
+            $float = 'right';
         }
         else if ($align == 'left') {
-            $style = "style='float:left;margin-right:40px;max-width:280px;' ";
+            $float = 'left';
+        }
+        else {
+            $float = 'none';
         }
 
-        $mwImage = "<img src='$src' width='$width' $style";
+        $imageFragment = parse_url($src, PHP_URL_PATH);
+        $imageFile = basename($imageFragment);
+
+        $mwImage = "[[File:{$imageFile}|thumb|{$float}";
         if ($alt != 'No Caption Provided') {
-            $mwImage .= "alt='$alt' ";
+            $mwImage .= "|alt={$alt}|{$alt}";
         }
-        $mwImage .= "/>\n";
+        $mwImage .= "]] ";
 
         return $mwImage;
     }


### PR DESCRIPTION
https://github.com/Giant-Bomb-Dot-Com/giant-bomb-wiki/issues/42

## Purpose

With the completion of https://github.com/Giant-Bomb-Dot-Com/giant-bomb-wiki/issues/33, the images in the description can now be replaced with [File: image filename.ext] instead of using an external link to the image. With this, the extension for external images can be removed.

