### PR TITLE
Added search bar that calls to main search

### DIFF
--- a/skins/GiantBomb/includes/templates/header.mustache
+++ b/skins/GiantBomb/includes/templates/header.mustache
@@ -1,9 +1,1 @@
-<div id="mw-header gb-header" class="gb-header">    
-    <div class="search-bar">
-        <input
-            id="gb-header-search"
-            v-model="searchText"
-            type="text"
-            placeholder="" /><button id="gb-header-btn" class="gb-header-btn">🔎︎</button>
-    </div>
-</div>
+<div id="gb-header" class="gb-header"></div>

--- a/skins/GiantBomb/includes/templates/landing-page.mustache
+++ b/skins/GiantBomb/includes/templates/landing-page.mustache
@@ -2,6 +2,8 @@
 
     {{> header }}
 
+    {{> search }}
+
     {{> wiki-button-group }}
 
     <div id="dynamic-content">

--- a/skins/GiantBomb/includes/templates/search.mustache
+++ b/skins/GiantBomb/includes/templates/search.mustache
@@ -1,0 +1,9 @@
+<div id="gb-search" class="gb-search">    
+    <div class="search-form">
+        <input
+            id="gb-search-bar"
+            v-model="searchText"
+            type="text"
+            placeholder="" /><button id="gb-search-btn" class="gb-search-btn">🔎︎</button>
+    </div>
+</div>

--- a/skins/GiantBomb/resources/css/search.css
+++ b/skins/GiantBomb/resources/css/search.css
@@ -1,14 +1,14 @@
-.gb-header {
+.gb-search {
   width: 50%;
 }
 
-.gb-header .search-bar {
+.gb-search .search-form {
   display: flex;
   flex-direction: row;
   height: 100%;
 }
 
-.gb-header input {
+.gb-search input {
   width: 90%;
   padding: 5px;
   background: #1a1a1a;
@@ -20,25 +20,25 @@
   transition: border-color 0.2s;
 }
 
-.gb-header input {
+.gb-search input {
   cursor: text;
 }
 
-.gb-header input:disabled {
+.gb-search input:disabled {
   cursor: not-allowed;
   opacity: 0.5;
 }
 
-.gb-header input:hover:not(:disabled) {
+.gb-search input:hover:not(:disabled) {
   border-color: #666;
 }
 
-.gb-header input:focus {
+.gb-search input:focus {
   outline: none;
   border-color: #e63946;
 }
 
-.gb-header-btn {
+.gb-search-btn {
   min-width: 10%;
   padding: 10px;
   background: #444;
@@ -50,11 +50,11 @@
   transition: all 0.2s;
 }
 
-.gb-header-btn:hover {
+.gb-search-btn:hover {
   background: #555;
   border-color: #888;
 }
 
-.gb-header-btn:active {
+.gb-search-btn:active {
   background: #333;
 }

--- a/skins/GiantBomb/resources/js/loadExternalHeader.js
+++ b/skins/GiantBomb/resources/js/loadExternalHeader.js
@@ -16,7 +16,7 @@
 
   // If no header URL is configured, hide the empty container
   if (!baseUrl) {
-    //hideEmptyContainer();
+    hideEmptyContainer();
     return;
   }
   // Load the external header CSS
@@ -36,13 +36,13 @@
       GiantBombHeader.render("gb-header");
     } else {
       console.error("GiantBombHeader not available after script load");
-      //hideEmptyContainer();
+      hideEmptyContainer();
     }
   };
 
   script.onerror = function () {
     console.error("Failed to load Giant Bomb header script");
-    //hideEmptyContainer();
+    hideEmptyContainer();
   };
 
   document.head.appendChild(script);

--- a/skins/GiantBomb/resources/js/search.js
+++ b/skins/GiantBomb/resources/js/search.js
@@ -1,13 +1,13 @@
 document
-  .getElementById("gb-header-search")
+  .getElementById("gb-search-bar")
   .addEventListener("keypress", function (event) {
     if (event.key === "Enter") {
       searchGBWiki($(this).val());
     }
   });
 
-document.getElementById("gb-header-btn").addEventListener("click", function () {
-  searchGBWiki(document.getElementById("gb-header-search").value);
+document.getElementById("gb-search-btn").addEventListener("click", function () {
+  searchGBWiki(document.getElementById("gb-search-bar").value);
 });
 
 function searchGBWiki(searchText) {

--- a/skins/GiantBomb/skin.json
+++ b/skins/GiantBomb/skin.json
@@ -28,7 +28,7 @@
     "skins.giantbomb.styles": {
       "styles": [
         "resources/css/styles.css",
-        "resources/css/header.css",
+        "resources/css/search.css",
         "resources/css/landingPage.css",
         "resources/css/gamePage.css",
         "resources/css/newReleasesPage.css"
@@ -42,7 +42,7 @@
     "skins.giantbomb.externalheader": {
       "scripts": [
         "resources/js/loadExternalHeader.js",
-        "resources/js/headerSearch.js"
+        "resources/js/search.js"
       ],
       "position": "top"
     },


### PR DESCRIPTION
Calls using a relative path, which will only work when main site runs with a /wiki for the wiki. Assumes a type=wiki will be added for filtering by @chuck-giantbomb .

Could also not even have a search in the wiki code and use search bar or a button/modal from the externally loaded header.
This at least does MVP search functionality if nothing else can be done in time.