### PR TITLE
chore(phpunit): fix running the php tests

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -59,17 +59,23 @@ RUN cd /var/www/html \
 RUN cp /usr/local/etc/php/php.ini-production /usr/local/etc/php/php.ini && \
     sed -i -e "s/^ *memory_limit.*/memory_limit = 4G/g" /usr/local/etc/php/php.ini
 
+# Directory for logging
+RUN mkdir -p -m 740 /var/log/mediawiki && \
+    chown -R www-data:www-data /var/log/mediawiki
+
 # Custom extensions packaged with the image
 COPY --chown=www-data:www-data ./extensions/GiantBombResolve /var/www/html/extensions/GiantBombResolve
 
-# So can be docker exec after build
+# Installation script for a new wiki (which copies the LocalSettings.php)
 COPY --chmod=755 installwiki.sh /installwiki.sh
+
+# Configurations for test suites
+COPY --chown=www-data:www-data phpunit.xml.dist /var/www/html/phpunit.xml.dist
 
 # START CONTAINER
 # Route /wiki/* to docroot for ResourceLoader and API when served under a path prefix
 COPY .htaccess /var/www/html/.htaccess
 
-COPY --chown=www-data:www-data phpunit.xml.dist /var/www/html/phpunit.xml.dist
 COPY --chmod=755 scripts/wiki-admin.sh /usr/local/bin/wiki-admin
 COPY entrypoint.sh /entrypoint.sh
 ENTRYPOINT ["/bin/sh", "/entrypoint.sh"]

--- a/Dockerfile.prod
+++ b/Dockerfile.prod
@@ -56,11 +56,15 @@ RUN cd /var/www/html \
 RUN cp /usr/local/etc/php/php.ini-production /usr/local/etc/php/php.ini && \
     sed -i -e "s/^ *memory_limit.*/memory_limit = 4G/g" /usr/local/etc/php/php.ini
 
+# Directory for logging
+RUN mkdir -p -m 740 /var/log/mediawiki && \
+    chown -R www-data:www-data /var/log/mediawiki
+
 # Custom extensions packaged with the image
 COPY --chown=www-data:www-data ./extensions/GiantBombResolve /var/www/html/extensions/GiantBombResolve
 COPY --chown=www-data:www-data ./extensions/AlgoliaSearch /var/www/html/extensions/AlgoliaSearch
 
-# So can be docker exec after build
+# Installation script for a new wiki (which copies the LocalSettings.php)
 COPY --chmod=755 installwiki.sh /installwiki.sh
 
 # START CONTAINER - PRODUCTION: Copy config and skin into image

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # The Giant Bomb Wiki
 
-A MediaWiki-based wiki for Giant Bomb game data, powered by Semantic MediaWiki.
+A MediaWiki-based wiki for Giant Bomb game data, powered by Semantic MediaWiki. The current LTS version of MediaWiki is 1.43.5.
 
 ## Quick Start (Recommended)
 
@@ -195,6 +195,25 @@ pnpm install
 ```
 
 This will install packages defined in the [pnpm workspace config file](pnpm-workspace.yaml).
+
+### [PHP Testing](#php-testing)
+
+#### Testing Mediawiki Tests
+
+Install the wiki first
+
+```
+docker compose exec wiki composer install
+docker compose exec wiki composer phpunit:unit
+```
+
+#### Testing GB Tests
+
+```
+composer phpunit -- gb-tests
+```
+
+To execute only a single file, pass the path the test after the double hyphen.
 
 ### E2E Testing
 

--- a/config/LocalSettings.php
+++ b/config/LocalSettings.php
@@ -159,17 +159,17 @@ $wgExternalDataSources['gb_api_dump'] = [
     'password' => getenv("MARIADB_PASSWORD")
 ];
 
-$wgExternalDatabases['external_db'] = [ 
-    'class' => 'DatabaseLoadBalancer', 
-    'hosts' => [ 
-        [ 
+$wgExternalDatabases['external_db'] = [
+    'class' => 'DatabaseLoadBalancer',
+    'hosts' => [
+        [
             'type' => 'mysql',
-            'host' => getenv( 'EXTERNAL_DB_HOST' ), 
+            'host' => getenv( 'EXTERNAL_DB_HOST' ),
             'dbname' => getenv( 'EXTERNAL_DB_NAME' ),
             'user' => getenv( 'EXTERNAL_DB_USER' ),
-            'password' => getenv( 'EXTERNAL_DB_PASSWORD' ) 
-        ] 
-    ] 
+            'password' => getenv( 'EXTERNAL_DB_PASSWORD' )
+        ]
+    ]
 ];
 
 
@@ -389,5 +389,10 @@ $smwgQMaxLimit = 15000;
 #Allow a large range of conditions in SMW queries
 $smwgQMaxSize = 100;
 
-#Allow custom favicon location 
+#Allow custom favicon location
 $wgFavicon = "$wgStylePath/GiantBomb/resources/assets/favicon.ico";
+
+# Scribunto is a default Mediawiki extension that permits scripting languages in Mediawiki pages
+$wgScribuntoDefaultEngine = 'luastandalone';
+$wgScribuntoEngineConf['luastandalone']['errorFile'] = '/var/log/mediawiki/lua_err.log';
+$wgScribuntoEngineConf['luastandalone']['memoryLimit'] = 209715200; # bytes, 200 MB

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,11 +14,14 @@ services:
       retries: 5
 
   wiki:
+    platform: "linux/amd64"
     build:
       context: .
       args:
         INSTALL_API: "false"
         INSTALL_GCSFUSE: "false"
+      platforms:
+        - "linux/amd64" # gotcha for those on Apple Silicon
     env_file:
       - .env
     depends_on:
@@ -36,8 +39,10 @@ services:
       - ./config:/config
       - ./data:/data/
       - wiki-data:/var/www/html/images
+      - ./tests:/var/www/html/gb-tests
     environment:
       - MV_ENV=dev
+      - COMPOSER_ROOT_VERSION=1.43.5
     restart: unless-stopped
 
 volumes:

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,0 +1,106 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit bootstrap="tests/phpunit/bootstrap.php"
+		 xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+		 xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd"
+		 colors="true"
+		 backupGlobals="false"
+		 convertDeprecationsToExceptions="true"
+		 convertErrorsToExceptions="true"
+		 convertNoticesToExceptions="true"
+		 convertWarningsToExceptions="true"
+		 forceCoversAnnotation="true"
+		 failOnWarning="true"
+		 stopOnFailure="false"
+		 failOnRisky="true"
+		 beStrictAboutTestsThatDoNotTestAnything="true"
+		 beStrictAboutOutputDuringTests="true"
+		 verbose="false"
+		 printerClass="MediaWikiPHPUnitResultPrinter"
+		 stderr="true">
+	<!-- Output only to stderr to avoid "Headers already sent" problems -->
+	<php>
+		<ini name="memory_limit" value="-1" />
+		<ini name="max_execution_time" value="0" />
+	</php>
+	<testsuites>
+		<testsuite name="core:unit">
+			<directory>tests/phpunit/unit</directory>
+		</testsuite>
+		<testsuite name="extensions:unit">
+			<file>tests/phpunit/suites/ExtensionsUnitTestSuite.php</file>
+		</testsuite>
+		<testsuite name="skins:unit">
+			<file>tests/phpunit/suites/SkinsUnitTestSuite.php</file>
+		</testsuite>
+		<testsuite name="includes">
+			<directory>tests/phpunit/includes</directory>
+		</testsuite>
+		<testsuite name="parsertests">
+			<file>tests/phpunit/suites/CoreParserTestSuite.php</file>
+			<file>tests/phpunit/suites/ExtensionsParserTestSuite.php</file>
+		</testsuite>
+		<testsuite name="skins">
+			<directory>tests/phpunit/structure</directory>
+			<file>tests/phpunit/suites/ExtensionsTestSuite.php</file>
+		</testsuite>
+		<!-- As there is a class Maintenance, we cannot use the name "maintenance" directly -->
+		<testsuite name="maintenance_suite">
+			<directory>tests/phpunit/maintenance</directory>
+		</testsuite>
+		<testsuite name="structure">
+			<directory>tests/phpunit/structure</directory>
+		</testsuite>
+		<testsuite name="tests">
+			<directory>tests/phpunit/tests</directory>
+		</testsuite>
+		<testsuite name="extensions">
+			<directory>tests/phpunit/structure</directory>
+			<file>tests/phpunit/suites/ExtensionsTestSuite.php</file>
+			<file>tests/phpunit/suites/ExtensionsParserTestSuite.php</file>
+		</testsuite>
+		<testsuite name="integration">
+			<directory>tests/phpunit/integration</directory>
+		</testsuite>
+		<testsuite name="docs">
+			<directory>tests/phpunit/docs</directory>
+		</testsuite>
+	</testsuites>
+	<groups>
+		<exclude>
+			<group>Broken</group>
+		</exclude>
+	</groups>
+	<coverage includeUncoveredFiles="false">
+		<include>
+			<directory suffix=".php">includes</directory>
+			<directory suffix=".php">languages</directory>
+			<directory suffix=".php">maintenance</directory>
+			<directory suffix=".php">extensions</directory>
+			<directory suffix=".php">skins</directory>
+		</include>
+		<exclude>
+			<directory suffix=".php">languages/messages</directory>
+			<directory suffix=".php">maintenance/benchmarks</directory>
+			<directory suffix=".php">extensions/*/tests</directory>
+			<directory suffix=".php">skins/*/tests</directory>
+		</exclude>
+	</coverage>
+	<listeners>
+		<listener class="JohnKary\PHPUnit\Listener\SpeedTrapListener">
+			<arguments>
+				<array>
+					<element key="slowThreshold">
+						<integer>100</integer>
+					</element>
+					<element key="reportLength">
+						<integer>10</integer>
+					</element>
+				</array>
+			</arguments>
+		</listener>
+	</listeners>
+	<extensions>
+		<extension class="MediaWikiLoggerPHPUnitExtension" />
+		<extension class="MediaWikiTeardownPHPUnitExtension" />
+	</extensions>
+</phpunit>


### PR DESCRIPTION
    * To run the php tests, we need to execute phpunit from within the wiki
    container. It was also missing the phpunit.xml to boostrap mediawiki. That was taken from the Mediawiki 1.43.5 tag github repo.
    * Mounted the GB-related php tests into the wiki container so they can
    also be run more easily from inside.
    * Configured Dockerfile to target linux/amd64 so that those on Apple
    Silicon will have a container that can run Lua correctly (for some
    php tests).
