### PR TITLE
chore(db): update the database version to the current LTS

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,6 @@
 services:
   db:
-    image: mariadb:11
+    image: mariadb:lts
     command: --skip-name-resolve=0
     ports:
       - "3306:3306"

--- a/docker/db-snapshot/Dockerfile
+++ b/docker/db-snapshot/Dockerfile
@@ -1,5 +1,5 @@
 # Custom MariaDB image with Giant Bomb Wiki data pre-loaded
-FROM mariadb:11.2
+FROM mariadb:lts
 
 # Copy database setup SQL (creates databases and grants permissions)
 COPY 00-setup-databases.sql /docker-entrypoint-initdb.d/


### PR DESCRIPTION
For https://github.com/Giant-Bomb-Dot-Com/giant-bomb-wiki/issues/127

Use the LTS version for mariadb