### PR TITLE
feat(security): restrict the SpecialPage Export/Import to sysop

### DIFF
--- a/config/LocalSettings.php
+++ b/config/LocalSettings.php
@@ -540,3 +540,12 @@ $wgHooks['ParserBeforeInternalParse'][] = function( &$parser, &$text, &$strip_st
 // user permissions
 $wgGroupPermissions['*']['createaccount'] = false;
 $wgGroupPermissions['sysop']['createaccount'] = true;
+
+function RestrictImportExport(&$list) {
+    if (!RequestContext::getMain()->getUser()->isAllowed('editinterface')) {
+        unset($list['Export']);
+        unset($list['Import']);
+    }
+    return true;
+}
+$wgHooks['SpecialPage_initList'][]='RestrictImportExport';


### PR DESCRIPTION
When a user who doesn't have the `editinterface` right tries to access the Export page:
<img width="534" height="297" alt="Screenshot 2026-02-02 at 4 57 03 PM" src="https://github.com/user-attachments/assets/d9762764-36b8-491f-a685-3049c78f7c27" />

A sysop has `editinterface`

<img width="1442" height="473" alt="Screenshot 2026-02-02 at 4 58 20 PM" src="https://github.com/user-attachments/assets/fa856213-4027-4bb3-8190-982c2e8f295b" />

