### PR TITLE
chore(ci): fixed building via compose due to phpunit security advisory

### DIFF
--- a/.github/workflows/test_e2e.yaml
+++ b/.github/workflows/test_e2e.yaml
@@ -5,7 +5,7 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
       - name: Create the .env file the installation will require
         run: |
           echo "MARIADB_DATABASE: gb_wiki_ci" >> .env
@@ -49,12 +49,12 @@ jobs:
           docker exec giant-bomb-wiki-wiki-1 /bin/bash /installwiki.sh
           docker compose logs --tail=50 > logs.txt
       - name: Upload docker logs
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: container-logs
           path: logs.txt
       - name: Run E2E tests
-        uses: cypress-io/github-action@v6
+        uses: cypress-io/github-action@v7
         with:
           wait-on: "http://localhost:8080"
           wait-on-timeout: 180 # seconds

--- a/Dockerfile.prod
+++ b/Dockerfile.prod
@@ -6,14 +6,13 @@ ARG INSTALL_API="false"
 WORKDIR /var/www/html
 USER root
 
-# INSTALL DB EXTENSIONS
-RUN docker-php-ext-install pdo pdo_mysql
-
-# INSTALL SEMANTIC MEDIAWIKI
 RUN set -x; \
     apt-get update \
  && apt-get upgrade -y \
  && apt-get install gnupg lsb-release libzip-dev unzip wget -y
+
+# INSTALL DB EXTENSIONS
+RUN docker-php-ext-install pdo pdo_mysql
 
 COPY --from=composer:latest /usr/bin/composer /usr/local/bin/composer
 
@@ -34,7 +33,9 @@ RUN if [ "$INSTALL_GCSFUSE" = "true" ]; then \
     apt-get update && apt-get install -y gcsfuse; \
     fi
 
+# INSTALL SEMANTIC MEDIAWIKI
 RUN cd /var/www/html \
+ && sed -i -e "s/9.6.19/\^9.6.19/" composer.json \
  && COMPOSER=composer.local.json php /usr/local/bin/composer require --no-update mediawiki/semantic-media-wiki \
  && php /usr/local/bin/composer require --no-update mediawiki/semantic-extra-special-properties \
  && php /usr/local/bin/composer require --no-update mediawiki/semantic-result-formats \


### PR DESCRIPTION
For security advisory https://issues.apache.org/jira/browse/IGNITE-27681

composer.json within Mediawiki 1.43.6 hard-sets the version of phpunit to 9.6.19, the version affected. Until an update is made to the Mediawiki image, we need to force update the composer.json file in order to update phpunit.

Also include some github action version updates and re-ordering in the Dockerfile.