### PR TITLE
Fix favicon path to use root /favicon.ico

### DIFF
--- a/config/LocalSettings.php
+++ b/config/LocalSettings.php
@@ -444,7 +444,7 @@ if ( $wikiEnv === 'dev' ) {
     $smwgQueryResultCacheLifetime = 0;  # Disable SMW query cache
 }
 
-$wgFavicon = "$wgStylePath/GiantBomb/resources/assets/favicon.ico";
+$wgFavicon = '/favicon.ico';
 
 # Scribunto/Lua
 $wgScribuntoDefaultEngine = 'luastandalone';


### PR DESCRIPTION
Fixes #154.\n\nThe skin-relative favicon path currently points to a URL that is not resolving correctly in production. This updates  to the site root favicon path (), which matches the intended URL from the issue.\n\n### Change\n- \n  - from: \n  - to: 