### PR TITLE
Fix lua error on reviews when missing an image

### DIFF
--- a/config/LocalSettings.php
+++ b/config/LocalSettings.php
@@ -376,6 +376,7 @@ wfLoadExtension("PageImages");
 wfLoadExtension("ParserFunctions");
 wfLoadExtension("Popups");
 wfLoadExtension("Scribunto");
+wfLoadExtension("GBModeration"); #needs to run before SemanticMediaWiki to ensure moderation tables are created before SMW tables
 wfLoadExtension("SemanticExtraSpecialProperties");
 wfLoadExtension("SemanticMediaWiki");
 wfLoadExtension("SemanticResultFormats");
@@ -391,7 +392,6 @@ wfLoadExtension("GiantBombResolve");
 wfLoadExtension("AlgoliaSearch");
 wfLoadExtension("UrlGetParameters");
 wfLoadExtension("GiantBombMetaTags");
-wfLoadExtension("GBModeration");
 wfLoadExtension("GBGallery");
 wfLoadExtension("VisualEditor");
 wfLoadExtension("VEForAll");

--- a/skins/GiantBomb/forms/wiki/Form_DLC.wikitext
+++ b/skins/GiantBomb/forms/wiki/Form_DLC.wikitext
@@ -58,7 +58,7 @@ if a page with that name already exists, you will be sent to a form to edit that
 |}
 {| class="formtable"
 ! style="width: 150px;" | Release Date Type: 
-| {{{field|ReleaseDateType|property=Has release date type|input type=dropdown|mandatory|show on select=None=>default;Full=>full_date;Month=>month_year;Quarter=>quarter_year;Year=>only_year|default=Full}}}
+| {{{field|ReleaseDateType|property=Has release date type|input type=dropdown|mandatory|show on select=None=>default;Full=>full_date;Month=>month_year;Quarter=>quarter_year;Year=>only_year|default=None}}}
 |}
 {{#if: {{#invoke:DateHelper|displayLegacyWarning}} |
 <div id="legacy-warning" style="background-color: #fff3cd; border: 1px solid #ffeeba; color: #856404; padding: 15px; margin-bottom: 20px; border-radius: 4px;">

--- a/skins/GiantBomb/forms/wiki/Form_Game.wikitext
+++ b/skins/GiantBomb/forms/wiki/Form_Game.wikitext
@@ -40,7 +40,7 @@ if a page with that name already exists, you will be sent to a form to edit that
 }}
 {| class="formtable"
 ! style="width: 150px;" | Release Date Type: 
-| {{{field|ReleaseDateType|property=Has release date type|input type=dropdown|mandatory|show on select=None=>default;Full=>full_date;Month=>month_year;Quarter=>quarter_year;Year=>only_year|default=Full}}}
+| {{{field|ReleaseDateType|property=Has release date type|input type=dropdown|mandatory|show on select=None=>default;Full=>full_date;Month=>month_year;Quarter=>quarter_year;Year=>only_year|default=None}}}
 |}
 <div id="default">
 </div>

--- a/skins/GiantBomb/forms/wiki/Form_Platform.wikitext
+++ b/skins/GiantBomb/forms/wiki/Form_Platform.wikitext
@@ -36,7 +36,7 @@ if a page with that name already exists, you will be sent to a form to edit that
 |}
 {| class="formtable"
 ! style="width: 150px;" | Release Date Type: 
-| {{{field|ReleaseDateType|property=Has release date type|input type=dropdown|mandatory|show on select=None=>default;Full=>full_date;Month=>month_year;Quarter=>quarter_year;Year=>only_year|default=Full}}}
+| {{{field|ReleaseDateType|property=Has release date type|input type=dropdown|mandatory|show on select=None=>default;Full=>full_date;Month=>month_year;Quarter=>quarter_year;Year=>only_year|default=None}}}
 |}
 {{#if: {{#invoke:DateHelper|displayLegacyWarning}} |
 <div id="legacy-warning" style="background-color: #fff3cd; border: 1px solid #ffeeba; color: #856404; padding: 15px; margin-bottom: 20px; border-radius: 4px;">

--- a/skins/GiantBomb/forms/wiki/Form_Releases.wikitext
+++ b/skins/GiantBomb/forms/wiki/Form_Releases.wikitext
@@ -52,7 +52,7 @@ if a page with that name already exists, you will be sent to a form to edit that
 |}
 {| class="formtable"
 ! style="width: 150px;" | Release Date Type: 
-| {{{field|ReleaseDateType|property=Has release date type|input type=dropdown|mandatory|show on select=None=>default;Full=>full_date;Month=>month_year;Quarter=>quarter_year;Year=>only_year|default=Full}}}
+| {{{field|ReleaseDateType|property=Has release date type|input type=dropdown|mandatory|show on select=None=>default;Full=>full_date;Month=>month_year;Quarter=>quarter_year;Year=>only_year|default=None}}}
 |}
 {{#if: {{#invoke:DateHelper|displayLegacyWarning}} |
 <div id="legacy-warning" style="background-color: #fff3cd; border: 1px solid #ffeeba; color: #856404; padding: 15px; margin-bottom: 20px; border-radius: 4px;">

--- a/skins/GiantBomb/modules/wiki/Module_ReviewQuery.wikitext
+++ b/skins/GiantBomb/modules/wiki/Module_ReviewQuery.wikitext
@@ -131,7 +131,7 @@ function p._renderSidebar(guid, hideReadButton)
     if staffReviews ~= nil then staffReview = staffReviews[1] end
     if staffReview ~= nil then
         local staffReviewURL = "https://giantbomb.com/reviews/" .. staffReview.slug
-        local staffBG = staffReview.featured_image.url
+        local staffBG = (staffReview.featured_image and staffReview.featured_image.url) or ""
         local staffReviewDeck = staffReview.deck    
         local avgOutOfFive = staffReview.score
         local starScore = (avgOutOfFive / 5) * 100


### PR DESCRIPTION
Also a fix for the build for "new" deploys so it creates the moderation tables correctly before SMW tries to use them.

@chuck-giantbomb Code is done for full deploy but can be done as a temp / quick fix by:

https://giantbomb.com/wiki/Module:ReviewQuery?action=edit

and changing line 134 from:
`local staffBG = staffReview.featured_image.url`
to
`local staffBG = (staffReview.featured_image and staffReview.featured_image.url) or ""`