### PR TITLE
Clickable Platform Badges on Game page and in Game Listing cards

### DIFF
--- a/import_templates/import_all_templates.php
+++ b/import_templates/import_all_templates.php
@@ -221,6 +221,7 @@ class ImportWikiTemplates extends Maintenance
 
             "Module:DateHelper" => "$moduleDir/Module_DateHelper.wikitext",
             "Module:ImageUrl" => "$moduleDir/Module_ImageUrl.wikitext",
+            "Module:PlainTitle" => "$moduleDir/Module_PlainTitle.wikitext",
             "Template:DateDisplay" => "$templateDir/Template_DateDisplay.wikitext",
 
             //images page

--- a/skins/GiantBomb/modules/wiki/Module_BadgeList.wikitext
+++ b/skins/GiantBomb/modules/wiki/Module_BadgeList.wikitext
@@ -1,4 +1,5 @@
 local p = {}
+local plainTitle = require("Module:PlainTitle")
 
 function p.format(frame)
     local input = frame.args[1] or ""
@@ -32,12 +33,18 @@ function p.format(frame)
             if platformData and platformData[1] and platformData[1].shortname then
                 local sn = platformData[1].shortname
                 -- If SMW returns a table (multiple shortnames), take the first one
-                displayText = type(sn) == "table" and sn[1] or sn
+                displayText = plainTitle.plain(type(sn) == "table" and sn[1] or sn)
             end
-                
-            table.insert(results, '<span class="platform-badge" title="' .. cleanName  .. '">' .. displayText .. '</span>')
+
+            -- 3. resolve the page for the platform
+            local t = mw.title.new(name)
+            local linkText = displayText
+            if t then
+                linkText = '[[' .. name .. '|' .. displayText .. mw.ustring.char(0x200B) .. ']]' --added zero width whitespace character ensures that title is different meaning PC doesn't get replaced by PC(PLATFORM)
+            end
+            table.insert(results, '<span class="platform-badge" title="' .. cleanName .. '">' .. linkText .. '</span>')
         else
-            -- 3. PLUS BADGE: Tooltip for remaining hidden items
+            -- 4. PLUS BADGE: Tooltip for remaining hidden items
             local remainingNames = {}
             for j = i, totalItems do
                 local n = items[j]:gsub("^[Pp][Ll][Aa][Tt][Ff][Oo][Rr][Mm][Ss]/", "")

--- a/skins/GiantBomb/modules/wiki/Module_GameSidebar.wikitext
+++ b/skins/GiantBomb/modules/wiki/Module_GameSidebar.wikitext
@@ -1,6 +1,7 @@
 -- game page sidebar: one smw query replaces the per-property #show storm.
 -- accordions come ranked from gb_related, own smw values fill in pre-backfill
 local p = {}
+local plainTitle = require("Module:PlainTitle")
 
 local smwData, store
 
@@ -53,15 +54,6 @@ local function joinLinks(v, sep)
     return table.concat(out, sep or ', ')
 end
 
--- smw hands values back as wikitext links (with a leading colon) -> unwrap
-local function plain(v)
-    local inner = tostring(v):match('^%[%[(.-)%]%]$')
-    if inner then
-        inner = inner:match('^(.-)|') or inner
-        return inner:gsub('^:', '')
-    end
-    return tostring(v)
-end
 
 -- the gb image server serves every upload in each rendition bucket ->
 -- swap whatever is stored for the small one
@@ -82,7 +74,7 @@ local function fetchCompanyLogos(...)
     local titles, seen = {}, {}
     for _, list in ipairs({ ... }) do
         for _, link in ipairs(list) do
-            local t = plain(link)
+            local t = plainTitle.plain(link)
             if t ~= '' and not seen[t] then
                 seen[t] = true
                 titles[#titles + 1] = t
@@ -107,7 +99,7 @@ local function fetchCompanyLogos(...)
             end
             local url = img and logoUrl(img)
             if url then
-                out[plain(r.page)] = url
+                out[plainTitle.plain(r.page)] = url
             end
         end
     end
@@ -120,7 +112,7 @@ local FALLBACK_LOGO =
 local function companyList(v, logos)
     local out = {}
     for _, link in ipairs(values(v)) do
-        local title = plain(link)
+        local title = plainTitle.plain(link)
         local url = logos[title] or FALLBACK_LOGO
         -- [pageUrl imageUrl] -> the parser wraps the external image in the
         -- link, so the thumbnail itself is clickable

--- a/skins/GiantBomb/modules/wiki/Module_PlainTitle.wikitext
+++ b/skins/GiantBomb/modules/wiki/Module_PlainTitle.wikitext
@@ -1,0 +1,14 @@
+local p = {}
+
+-- extracting the plain() function from GameSidebar to be used by multiple modules
+-- smw hands values back as wikitext links (with a leading colon) -> unwrap
+function p.plain(v)
+    local inner = tostring(v):match('^%[%[(.-)%]%]$')
+    if inner then
+        inner = inner:match('^(.-)|') or inner
+        return inner:gsub('^:', '')
+    end
+    return tostring(v)
+end
+
+return p

--- a/skins/GiantBomb/resources/css/listingPage.css
+++ b/skins/GiantBomb/resources/css/listingPage.css
@@ -389,6 +389,32 @@
   color: #ccc;
 }
 
+.platform-badge a {
+  display: block;
+  margin: -4px -8px;   /* matches .platform-badge's padding: 4px 8px */
+  padding: 4px 8px;    /* re-applies it on the link itself */
+  text-decoration: none;
+}
+
+.platform-badge a:link,
+.platform-badge a:visited {
+  color: inherit;
+}
+
+.gb-game-hero-platform a {
+  display: block;
+  margin: -0.25rem -0.6rem;   /* matches .gb-game-hero-platform's padding */
+  padding: 0.25rem 0.6rem;
+  color: inherit;
+  text-decoration: none;
+}
+
+.gb-game-hero-platform a:link,
+.gb-game-hero-platform a:visited {
+  color: inherit;
+}
+
+
 .platform-badge-more {
   background: #1a1a1a;
   color: #999;

--- a/skins/GiantBomb/resources/js/game-sidebar-tabs.js
+++ b/skins/GiantBomb/resources/js/game-sidebar-tabs.js
@@ -233,18 +233,6 @@
       link.textContent = text.replace(/_/g, " ");
     }
 
-    for (const span of document.querySelectorAll(
-      ".gb-game-hero-platform, .gb-franchise-game-platform",
-    )) {
-      let text = span.textContent;
-      for (const prefix of prefixes) {
-        if (text.startsWith(prefix)) {
-          text = text.replace(prefix, "");
-          break;
-        }
-      }
-      span.textContent = text.replace(/_/g, " ");
-    }
   };
 
   const initSidebarTabs = () => {


### PR DESCRIPTION
Closes #137 

Badges were previously just plain text. They are now clickable and lead to platform pages.

- Extracted the plain() helper function from Module:GameSideBar into new Module:PlainTitle enabling it to also be used in Module:BadgeList without duplicating logic.
- Module:BadgeList now builds real links for each badge.
- The DisplayTitle Extention overrides link text that exactly matches the target page's raw title. This causes an issue where "PC" on the badge is corrected to "PC (PLATFORM)" to work around this a zero-width whitespace character is appended to the end of the link text. This is probably worth looking into in the future.
-  Added CSS styling to badge links so that they fill the whole box and don't appear as blue/purple links.
-  Removed a block in game-sidebar-tabs.js this block was silently deleting the link client-side after page load and wasn't nessesary to achieve the prefix stripping peformed in the file. As a sidenote, the client-side prefix stripping is worth looking into because it wasn't nessesary on the game listing cards.