### PR TITLE
Removes the '?Has name' column from the recent games sidebar for Themes and Genres

### DIFF
--- a/skins/GiantBomb/templates/wiki/Template_GenreSidebar.wikitext
+++ b/skins/GiantBomb/templates/wiki/Template_GenreSidebar.wikitext
@@ -35,7 +35,6 @@ This template is called automatically by <code><nowiki>{{GenreEnd}}</nowiki></co
 <div class="gb-accordion-header">Recent Games</div>
 <ul class="gb-accordion-content">
 {{#ask: [[Has genres::{{FULLPAGENAME}}]] [[Category:Games]]
-  |?Has name
   |format=list
   |link=all
   |limit=20

--- a/skins/GiantBomb/templates/wiki/Template_ThemeSidebar.wikitext
+++ b/skins/GiantBomb/templates/wiki/Template_ThemeSidebar.wikitext
@@ -35,7 +35,6 @@ This template is called automatically by <code><nowiki>{{ThemeEnd}}</nowiki></co
 <div class="gb-accordion-header">Recent Games</div>
 <ul class="gb-accordion-content">
 {{#ask: [[Has themes::{{FULLPAGENAME}}]] [[Category:Games]]
-  |?Has name
   |format=list
   |link=all
   |limit=20


### PR DESCRIPTION
Removes the '?Has name' column from the recent games sidebar for Themes and Genres inorder to get rid of the extraneous information listed:

<img width="716" height="566" alt="image" src="https://github.com/user-attachments/assets/812f1f7d-b5df-401a-a594-4edad517685b" />
