### PR TITLE
PR 214 (Part2) - Improvement for Wiki 'Accordions'

### DIFF
--- a/skins/GiantBomb/resources/js/game-sidebar-tabs.js
+++ b/skins/GiantBomb/resources/js/game-sidebar-tabs.js
@@ -325,7 +325,7 @@
           accordion.classList.toggle("gb-accordion--active");
         }
       }
-      // Otherwise, open all by default (add --open and --active
+      // Otherwise, open all by default (add --open and --active)
       else {
         if (!accordion.classList.contains("gb-accordion--open")) {
           accordion.classList.toggle("gb-accordion--open");
@@ -334,8 +334,10 @@
           accordion.classList.toggle("gb-accordion--active");
         }
 
-        // And close if it does not have content
-        if (content.querySelector('span[class*="smw-value"]') == null)
+        // And close if it does not have content.  
+        // Making the assumption that all Accordions that are not empty will contain links to other 
+        // Wiki Pages.  Therefore, if it has a link, it is not empty.
+        if (content.querySelector("a[href]") == null)
         {
           if (accordion.classList.contains("gb-accordion--open")) {
             accordion.classList.toggle("gb-accordion--open");


### PR DESCRIPTION
Updated game-sidebar-tabs.js, function initAccordions ().

Change how the function determines if an Accordion has data:
  - From using "gb-accordion-content" having a span with a class of "smw-value"
  - To using "gb-accordion-content" has an a href

This does give 'false positives' when an Accordion has 'None' but also has the 'view all ->' link in the local page (for instance a 'Company' page where 'Developed Games' and/or 'Published Games' have no linked entries).

But I think this is better to have some 'empty' ones open, instead of having all Accordions closed (due to no longer having 'smw-value' classes).

And I think going forward, it it will help if other categories transition to also not have 'smw-value' classes, as I am fairly certain the Accordions (when not empty) will always have links to other pages in the wiki.